### PR TITLE
Service file updates

### DIFF
--- a/applications/AdaptiveApplication1/proc1.service
+++ b/applications/AdaptiveApplication1/proc1.service
@@ -2,3 +2,4 @@
 Description=Adaptive Application 2 process 1
 [Service]
 Type=forking
+TimeoutStartSec=infinity

--- a/applications/AdaptiveApplication2/proc2.service
+++ b/applications/AdaptiveApplication2/proc2.service
@@ -2,3 +2,4 @@
 Description=Adaptive Application 2 process 2
 [Service]
 Type=forking
+TimeoutStartSec=infinity

--- a/applications/AdaptiveApplication2/proc3.service
+++ b/applications/AdaptiveApplication2/proc3.service
@@ -2,3 +2,4 @@
 Description=Adaptive Application 2 process 3
 [Service]
 Type=forking
+TimeoutStartSec=infinity

--- a/applications/MachineStateManager/msm.service
+++ b/applications/MachineStateManager/msm.service
@@ -2,3 +2,4 @@
 Description=Machine state manager
 [Service]
 Type=forking
+TimeoutStartSec=infinity


### PR DESCRIPTION
Systemd checks whether service exited after 90 seconds and if not - kills it. It is not applicable for AAs and MSM.

This pr disables the feature of systemd.